### PR TITLE
updates for hover states

### DIFF
--- a/lib/BodyView.js
+++ b/lib/BodyView.js
@@ -90,6 +90,7 @@ var BodyView = (_temp = _class = function (_Component) {
           }
           if (item.groupOnly) {
             style = _extends({}, style, { backgroundColor: config.groupOnlySlotColor });
+            className = 'group-only';
           }
           if (isToday) {
             className = 'today';

--- a/lib/EventItem.js
+++ b/lib/EventItem.js
@@ -127,6 +127,7 @@ var EventItem = (_temp = _class = function (_Component) {
           isEnd = _props.isEnd,
           isInPopover = _props.isInPopover,
           eventItemClick = _props.eventItemClick,
+          eventBoundingBoxClick = _props.eventBoundingBoxClick,
           schedulerData = _props.schedulerData,
           isDragging = _props.isDragging,
           connectDragSource = _props.connectDragSource,
@@ -191,7 +192,13 @@ var EventItem = (_temp = _class = function (_Component) {
         }
       }, eventItemTemplate, startResizeDiv, endResizeDiv);
 
-      return isDragging ? null : schedulerData._isResizing() || config.eventItemPopoverEnabled == false || eventItem.showPopover == false ? _react2.default.createElement('div', null, connectDragPreview(connectDragSource(a))) : _react2.default.createElement(_popover2.default, { placement: 'bottomLeft', content: content, trigger: 'hover' }, connectDragPreview(connectDragSource(a)));
+      return isDragging ? null : schedulerData._isResizing() || config.eventItemPopoverEnabled == false || eventItem.showPopover == false ? _react2.default.createElement('div', {
+        onClick: function onClick() {
+          if (eventItem.boundingBoxClickable && eventBoundingBoxClick) {
+            eventBoundingBoxClick(schedulerData, eventItem);
+          }
+        }
+      }, connectDragPreview(connectDragSource(a))) : _react2.default.createElement(_popover2.default, { placement: 'bottomLeft', content: content, trigger: 'hover' }, connectDragPreview(connectDragSource(a)));
     }
   }]);
 
@@ -215,6 +222,7 @@ var EventItem = (_temp = _class = function (_Component) {
   moveEvent: _propTypes.PropTypes.func,
   subtitleGetter: _propTypes.PropTypes.func,
   eventItemClick: _propTypes.PropTypes.func,
+  eventBoundingBoxClick: _propTypes.PropTypes.func,
   viewEventClick: _propTypes.PropTypes.func,
   viewEventText: _propTypes.PropTypes.string,
   viewEvent2Click: _propTypes.PropTypes.func,

--- a/lib/EventItem.js
+++ b/lib/EventItem.js
@@ -28,6 +28,10 @@ var _createClass = function () {
 
 var _class, _temp, _initialiseProps;
 
+var _Item = require('antd/lib/list/Item');
+
+var _Item2 = _interopRequireDefault(_Item);
+
 var _popover = require('antd/lib/popover');
 
 var _popover2 = _interopRequireDefault(_popover);
@@ -188,8 +192,9 @@ var EventItem = (_temp = _class = function (_Component) {
           leftOffset = leftOffset + cellWidth / 2;
         }
       }
+
       var a = _react2.default.createElement('a', {
-        className: 'timeline-event ' + eventItem.type,
+        className: 'timeline-event ' + eventItem.type + ' ' + (eventItem.boundingBoxClickable ? 'bounding-box-clickable' : ''),
         style: { left: leftOffset, width: width, top: top },
         onClick: function onClick() {
           if (!!eventItemClick) {

--- a/lib/EventItem.js
+++ b/lib/EventItem.js
@@ -181,10 +181,16 @@ var EventItem = (_temp = _class = function (_Component) {
       if (eventItemTemplateResolver != undefined) {
         eventItemTemplate = eventItemTemplateResolver(schedulerData, eventItem, bgColor, isStart, isEnd, 'event-item', config.eventItemHeight, undefined);
       }
-
+      var cellWidth = schedulerData.getContentCellWidth();
+      var leftOffset = left;
+      if (eventItem.eventStartMidDay) {
+        if (new Date(eventItem.start) > new Date(schedulerData.startDate) - 1) {
+          leftOffset = leftOffset + cellWidth / 2;
+        }
+      }
       var a = _react2.default.createElement('a', {
         className: 'timeline-event ' + eventItem.type,
-        style: { left: left, width: width, top: top },
+        style: { left: leftOffset, width: width, top: top },
         onClick: function onClick() {
           if (!!eventItemClick) {
             eventItemClick(schedulerData, eventItem);

--- a/lib/EventItem.js
+++ b/lib/EventItem.js
@@ -182,7 +182,7 @@ var EventItem = (_temp = _class = function (_Component) {
       }
 
       var a = _react2.default.createElement('a', {
-        className: 'timeline-event',
+        className: 'timeline-event ' + eventItem.type,
         style: { left: left, width: width, top: top },
         onClick: function onClick() {
           if (!!eventItemClick) {

--- a/lib/ResourceEvents.js
+++ b/lib/ResourceEvents.js
@@ -406,8 +406,8 @@ var ResourceEvents = (_temp = _class = function (_Component) {
               var eventEnd = localeMoment(evt.eventItem.end);
               var isStart = eventStart >= durationStart;
               var isEnd = eventEnd <= durationEnd;
-              var _left = index * cellWidth - index * 1;
-              var _width = evt.span * cellWidth;
+              var _left = index * cellWidth - index * .2;
+              var _width = evt.span * cellWidth + 1;
               var eventItem = _react2.default.createElement(DnDEventItem, _extends({}, _this2.props, {
                 key: evt.eventItem.id,
                 eventItem: evt.eventItem,

--- a/lib/ResourceEvents.js
+++ b/lib/ResourceEvents.js
@@ -406,8 +406,8 @@ var ResourceEvents = (_temp = _class = function (_Component) {
               var eventEnd = localeMoment(evt.eventItem.end);
               var isStart = eventStart >= durationStart;
               var isEnd = eventEnd <= durationEnd;
-              var _left = index * cellWidth - index * .2;
-              var _width = evt.span * cellWidth + 1;
+              var _left = index * cellWidth;
+              var _width = evt.span * cellWidth;
               var eventItem = _react2.default.createElement(DnDEventItem, _extends({}, _this2.props, {
                 key: evt.eventItem.id,
                 eventItem: evt.eventItem,

--- a/lib/ResourceEvents.js
+++ b/lib/ResourceEvents.js
@@ -406,9 +406,8 @@ var ResourceEvents = (_temp = _class = function (_Component) {
               var eventEnd = localeMoment(evt.eventItem.end);
               var isStart = eventStart >= durationStart;
               var isEnd = eventEnd <= durationEnd;
-              var _left = index * cellWidth + (index > 0 ? 2 : 3);
-              var _width = evt.span * cellWidth - (index > 0 ? 5 : 6) > 0 ? evt.span * cellWidth - (index > 0 ? 5 : 6) : 0;
-              var top = marginTop + idx * config.eventItemLineHeight;
+              var _left = index * cellWidth - index * 1;
+              var _width = evt.span * cellWidth;
               var eventItem = _react2.default.createElement(DnDEventItem, _extends({}, _this2.props, {
                 key: evt.eventItem.id,
                 eventItem: evt.eventItem,
@@ -417,7 +416,7 @@ var ResourceEvents = (_temp = _class = function (_Component) {
                 isInPopover: false,
                 left: _left,
                 width: _width,
-                top: top,
+                top: 0,
                 leftIndex: index,
                 rightIndex: index + evt.span
               }));

--- a/lib/ResourceView.js
+++ b/lib/ResourceView.js
@@ -149,7 +149,7 @@ var ResourceView = (_temp = _class = function (_Component) {
           });
         }
 
-        return _react2.default.createElement('tr', { key: item.slotId }, _react2.default.createElement('td', { 'data-resource-id': item.slotId, style: tdStyle }, slotItem));
+        return _react2.default.createElement('tr', { key: item.slotId }, _react2.default.createElement('td', { 'data-resource-id': item.slotId, style: tdStyle, className: item.groupOnly ? 'group-only' : '' }, slotItem));
       });
 
       return _react2.default.createElement('div', { style: { paddingBottom: paddingBottom } }, _react2.default.createElement('table', { className: 'resource-table' }, _react2.default.createElement('tbody', null, resourceList)));

--- a/lib/ResourceView.js
+++ b/lib/ResourceView.js
@@ -76,7 +76,6 @@ var ResourceView = (_temp = _class = function (_Component) {
           schedulerData = _props.schedulerData,
           contentScrollbarHeight = _props.contentScrollbarHeight,
           slotClickedFunc = _props.slotClickedFunc,
-          resourceCtaClickedFunc = _props.resourceCtaClickedFunc,
           slotItemTemplateResolver = _props.slotItemTemplateResolver,
           toggleExpandFunc = _props.toggleExpandFunc;
       var renderData = schedulerData.renderData;
@@ -117,24 +116,30 @@ var ResourceView = (_temp = _class = function (_Component) {
         }
         indents.push(indent);
 
-        var resourceCta = null;
-        if (item.resourceCta) {
-          resourceCta = _react2.default.createElement('div', { onClick: function onClick() {
-              return resourceCtaClickedFunc(item.slotId);
-            }, className: "resource-cta" }, item.resourceCta);
+        var resourceRightSide = null;
+        if (item.resourceRightSide) {
+          resourceRightSide = _react2.default.createElement('div', { className: "resource-right-side" }, item.resourceRightSide);
+        }
+        console.log(resourceRightSide, item.resourceRightSide);
+
+        var slotItem = void 0;
+        if (slotClickedFunc != undefined) {
+          slotItem = _react2.default.createElement('a', {
+            title: item.slotName,
+            className: 'overflow-text header2-text clickable',
+            style: { textAlign: 'left' },
+            onClick: function onClick() {
+              return slotClickedFunc(schedulerData, item);
+            }
+          }, _react2.default.createElement('span', { className: 'slot-cell' }, indents, _react2.default.createElement('span', { className: 'slot-text' }, item.slotName), resourceRightSide));
+        } else {
+          slotItem = _react2.default.createElement('div', {
+            title: item.slotName,
+            className: 'overflow-text header2-text non-clickable',
+            style: { textAlign: 'left' }
+          }, _react2.default.createElement('span', { className: 'slot-cell' }, indents, _react2.default.createElement('span', { className: 'slot-text' }, item.slotName), resourceRightSide));
         }
 
-        var a = slotClickedFunc != undefined ? _react2.default.createElement('span', { className: 'slot-cell' }, indents, _react2.default.createElement('a', {
-          className: 'slot-text',
-          onClick: function onClick() {
-            slotClickedFunc(schedulerData, item);
-          }
-        }, item.slotName)) : _react2.default.createElement('span', { className: 'slot-cell' }, indents, _react2.default.createElement('span', { className: 'slot-text' }, item.slotName), resourceCta);
-        var slotItem = _react2.default.createElement('div', {
-          title: item.slotName,
-          className: 'overflow-text header2-text',
-          style: { textAlign: 'left' }
-        }, a);
         if (!!slotItemTemplateResolver) {
           var temp = slotItemTemplateResolver(schedulerData, item, slotClickedFunc, width, 'overflow-text header2-text');
           if (!!temp) {
@@ -161,7 +166,6 @@ var ResourceView = (_temp = _class = function (_Component) {
   schedulerData: _propTypes.PropTypes.object.isRequired,
   contentScrollbarHeight: _propTypes.PropTypes.number.isRequired,
   slotClickedFunc: _propTypes.PropTypes.func,
-  resourceCtaClickedFunc: _propTypes.PropTypes.func,
   slotItemTemplateResolver: _propTypes.PropTypes.func,
   toggleExpandFunc: _propTypes.PropTypes.func
 }, _temp);

--- a/lib/ResourceView.js
+++ b/lib/ResourceView.js
@@ -116,30 +116,11 @@ var ResourceView = (_temp = _class = function (_Component) {
         }
         indents.push(indent);
 
-        var resourceRightSide = null;
-        if (item.resourceRightSide) {
-          resourceRightSide = _react2.default.createElement('div', { className: "resource-right-side" }, item.resourceRightSide);
-        }
-        console.log(resourceRightSide, item.resourceRightSide);
-
-        var slotItem = void 0;
-        if (slotClickedFunc != undefined) {
-          slotItem = _react2.default.createElement('a', {
-            title: item.slotName,
-            className: 'overflow-text header2-text clickable',
-            style: { textAlign: 'left' },
-            onClick: function onClick() {
-              return slotClickedFunc(schedulerData, item);
-            }
-          }, _react2.default.createElement('span', { className: 'slot-cell' }, indents, _react2.default.createElement('span', { className: 'slot-text' }, item.slotName), resourceRightSide));
-        } else {
-          slotItem = _react2.default.createElement('div', {
-            title: item.slotName,
-            className: 'overflow-text header2-text non-clickable',
-            style: { textAlign: 'left' }
-          }, _react2.default.createElement('span', { className: 'slot-cell' }, indents, _react2.default.createElement('span', { className: 'slot-text' }, item.slotName), resourceRightSide));
-        }
-
+        var slotItem = _react2.default.createElement('div', {
+          title: item.slotName,
+          className: 'overflow-text header2-text',
+          style: { textAlign: 'left' }
+        }, _react2.default.createElement('span', { className: 'slot-cell' }, indents, _react2.default.createElement('span', { className: 'slot-text' }, item.slotName), item.rightSide && _react2.default.createElement('div', { className: 'resource-right' }, item.rightSide)));
         if (!!slotItemTemplateResolver) {
           var temp = slotItemTemplateResolver(schedulerData, item, slotClickedFunc, width, 'overflow-text header2-text');
           if (!!temp) {
@@ -154,7 +135,14 @@ var ResourceView = (_temp = _class = function (_Component) {
           });
         }
 
-        return _react2.default.createElement('tr', { key: item.slotId }, _react2.default.createElement('td', { 'data-resource-id': item.slotId, style: tdStyle, className: item.groupOnly ? 'group-only' : '' }, slotItem));
+        return _react2.default.createElement('tr', { key: item.slotId }, _react2.default.createElement('td', {
+          'data-resource-id': item.slotId,
+          style: tdStyle,
+          className: item.groupOnly ? 'resource-group-only' : 'resource-row',
+          onClick: function onClick() {
+            slotClickedFunc(schedulerData, item);
+          }
+        }, slotItem));
       });
 
       return _react2.default.createElement('div', { style: { paddingBottom: paddingBottom } }, _react2.default.createElement('table', { className: 'resource-table' }, _react2.default.createElement('tbody', null, resourceList)));

--- a/lib/SchedulerData.js
+++ b/lib/SchedulerData.js
@@ -815,7 +815,8 @@ var SchedulerData = function () {
           indent: 0,
           hasChildren: false,
           expanded: true,
-          render: true
+          render: true,
+          rightSide: slot.rightSide
         };
         var id = slot.id;
         var value = undefined;

--- a/lib/SchedulerData.js
+++ b/lib/SchedulerData.js
@@ -815,8 +815,7 @@ var SchedulerData = function () {
           indent: 0,
           hasChildren: false,
           expanded: true,
-          render: true,
-          resourceCta: slot.resourceCta
+          render: true
         };
         var id = slot.id;
         var value = undefined;

--- a/lib/index.js
+++ b/lib/index.js
@@ -449,7 +449,6 @@ var Scheduler = (_temp = _class = function (_Component) {
   eventItemTemplateResolver: _propTypes.PropTypes.func,
   dndSources: _propTypes.PropTypes.array,
   slotClickedFunc: _propTypes.PropTypes.func,
-  resourceClickedFunc: _propTypes.PropTypes.func,
   toggleExpandFunc: _propTypes.PropTypes.func,
   slotItemTemplateResolver: _propTypes.PropTypes.func,
   nonAgendaCellHeaderTemplateResolver: _propTypes.PropTypes.func,

--- a/lib/index.js
+++ b/lib/index.js
@@ -441,6 +441,7 @@ var Scheduler = (_temp = _class = function (_Component) {
   newEvent: _propTypes.PropTypes.func,
   subtitleGetter: _propTypes.PropTypes.func,
   eventItemClick: _propTypes.PropTypes.func,
+  eventBoundingBoxClick: _propTypes.PropTypes.func,
   viewEventClick: _propTypes.PropTypes.func,
   viewEventText: _propTypes.PropTypes.string,
   viewEvent2Click: _propTypes.PropTypes.func,

--- a/lib/index.js
+++ b/lib/index.js
@@ -449,7 +449,7 @@ var Scheduler = (_temp = _class = function (_Component) {
   eventItemTemplateResolver: _propTypes.PropTypes.func,
   dndSources: _propTypes.PropTypes.array,
   slotClickedFunc: _propTypes.PropTypes.func,
-  resourceCtaClickedFunc: _propTypes.PropTypes.func,
+  resourceClickedFunc: _propTypes.PropTypes.func,
   toggleExpandFunc: _propTypes.PropTypes.func,
   slotItemTemplateResolver: _propTypes.PropTypes.func,
   nonAgendaCellHeaderTemplateResolver: _propTypes.PropTypes.func,

--- a/src/BodyView.js
+++ b/src/BodyView.js
@@ -27,6 +27,7 @@ class BodyView extends Component {
         }
         if (item.groupOnly) {
           style = { ...style, backgroundColor: config.groupOnlySlotColor }
+          className = 'group-only'
         }
         if (isToday) {
           className = 'today'

--- a/src/EventItem.js
+++ b/src/EventItem.js
@@ -650,8 +650,8 @@ class EventItem extends Component {
 
     let a = (
       <a
-        className="timeline-event"
-        style={{ left: left, width: width, top: top }}
+      className={`timeline-event ${eventItem.type}`}
+      style={{ left: left, width: width, top: top }}
         onClick={() => {
           if (!!eventItemClick) {
             eventItemClick(schedulerData, eventItem)

--- a/src/EventItem.js
+++ b/src/EventItem.js
@@ -649,11 +649,17 @@ class EventItem extends Component {
         undefined,
       )
     }
-
+    let cellWidth = schedulerData.getContentCellWidth()
+    let leftOffset = left
+    if (eventItem.eventStartMidDay) {
+      if (new Date(eventItem.start) > new Date(schedulerData.startDate) - 1) {
+        leftOffset = leftOffset + cellWidth / 2
+      }
+    }
     let a = (
       <a
         className={`timeline-event ${eventItem.type}`}
-        style={{ left: left, width: width, top: top }}
+        style={{ left: leftOffset, width: width, top: top }}
         onClick={() => {
           if (!!eventItemClick) {
             eventItemClick(schedulerData, eventItem)

--- a/src/EventItem.js
+++ b/src/EventItem.js
@@ -41,6 +41,7 @@ class EventItem extends Component {
     moveEvent: PropTypes.func,
     subtitleGetter: PropTypes.func,
     eventItemClick: PropTypes.func,
+    eventBoundingBoxClick: PropTypes.func,
     viewEventClick: PropTypes.func,
     viewEventText: PropTypes.string,
     viewEvent2Click: PropTypes.func,
@@ -574,6 +575,7 @@ class EventItem extends Component {
       isEnd,
       isInPopover,
       eventItemClick,
+      eventBoundingBoxClick,
       schedulerData,
       isDragging,
       connectDragSource,
@@ -650,8 +652,8 @@ class EventItem extends Component {
 
     let a = (
       <a
-      className={`timeline-event ${eventItem.type}`}
-      style={{ left: left, width: width, top: top }}
+        className={`timeline-event ${eventItem.type}`}
+        style={{ left: left, width: width, top: top }}
         onClick={() => {
           if (!!eventItemClick) {
             eventItemClick(schedulerData, eventItem)
@@ -667,7 +669,15 @@ class EventItem extends Component {
     return isDragging ? null : schedulerData._isResizing() ||
       config.eventItemPopoverEnabled == false ||
       eventItem.showPopover == false ? (
-      <div>{connectDragPreview(connectDragSource(a))}</div>
+      <div
+        onClick={() => {
+          if (eventItem.boundingBoxClickable && eventBoundingBoxClick) {
+            eventBoundingBoxClick(schedulerData, eventItem)
+          }
+        }}
+      >
+        {connectDragPreview(connectDragSource(a))}
+      </div>
     ) : (
       <Popover placement="bottomLeft" content={content} trigger="hover">
         {connectDragPreview(connectDragSource(a))}

--- a/src/EventItem.js
+++ b/src/EventItem.js
@@ -1,3 +1,4 @@
+import Item from 'antd/lib/list/Item'
 import Popover from 'antd/lib/popover'
 import 'antd/lib/popover/style/index.css'
 import { PropTypes } from 'prop-types'
@@ -656,9 +657,12 @@ class EventItem extends Component {
         leftOffset = leftOffset + cellWidth / 2
       }
     }
+
     let a = (
       <a
-        className={`timeline-event ${eventItem.type}`}
+        className={`timeline-event ${eventItem.type} ${
+          eventItem.boundingBoxClickable ? 'bounding-box-clickable' : ''
+        }`}
         style={{ left: leftOffset, width: width, top: top }}
         onClick={() => {
           if (!!eventItemClick) {

--- a/src/ResourceEvents.js
+++ b/src/ResourceEvents.js
@@ -313,8 +313,8 @@ class ResourceEvents extends Component {
             let eventEnd = localeMoment(evt.eventItem.end)
             let isStart = eventStart >= durationStart
             let isEnd = eventEnd <= durationEnd
-            let left = index * cellWidth - index * 1
-            let width = evt.span * cellWidth
+            let left = index * cellWidth - index * .2
+            let width = evt.span * cellWidth + 1
             let eventItem = (
               <DnDEventItem
                 {...this.props}

--- a/src/ResourceEvents.js
+++ b/src/ResourceEvents.js
@@ -313,11 +313,8 @@ class ResourceEvents extends Component {
             let eventEnd = localeMoment(evt.eventItem.end)
             let isStart = eventStart >= durationStart
             let isEnd = eventEnd <= durationEnd
-            let left = index * cellWidth + (index > 0 ? 2 : 3)
-            let width =
-              evt.span * cellWidth - (index > 0 ? 5 : 6) > 0
-                ? evt.span * cellWidth - (index > 0 ? 5 : 6)
-                : 0
+            let left = index * cellWidth - index * 1
+            let width = evt.span * cellWidth
             let top = marginTop + idx * config.eventItemLineHeight
             let eventItem = (
               <DnDEventItem
@@ -329,7 +326,6 @@ class ResourceEvents extends Component {
                 isInPopover={false}
                 left={left}
                 width={width}
-                top={top}
                 leftIndex={index}
                 rightIndex={index + evt.span}
               />

--- a/src/ResourceEvents.js
+++ b/src/ResourceEvents.js
@@ -313,8 +313,8 @@ class ResourceEvents extends Component {
             let eventEnd = localeMoment(evt.eventItem.end)
             let isStart = eventStart >= durationStart
             let isEnd = eventEnd <= durationEnd
-            let left = index * cellWidth - index * .2
-            let width = evt.span * cellWidth + 1
+            let left = index * cellWidth
+            let width = evt.span * cellWidth 
             let eventItem = (
               <DnDEventItem
                 {...this.props}

--- a/src/ResourceEvents.js
+++ b/src/ResourceEvents.js
@@ -315,7 +315,6 @@ class ResourceEvents extends Component {
             let isEnd = eventEnd <= durationEnd
             let left = index * cellWidth - index * 1
             let width = evt.span * cellWidth
-            let top = marginTop + idx * config.eventItemLineHeight
             let eventItem = (
               <DnDEventItem
                 {...this.props}
@@ -326,6 +325,7 @@ class ResourceEvents extends Component {
                 isInPopover={false}
                 left={left}
                 width={width}
+                top={0}
                 leftIndex={index}
                 rightIndex={index + evt.span}
               />

--- a/src/ResourceView.js
+++ b/src/ResourceView.js
@@ -124,7 +124,7 @@ class ResourceView extends Component {
 
       return (
         <tr key={item.slotId}>
-          <td data-resource-id={item.slotId} style={tdStyle}>
+          <td data-resource-id={item.slotId} style={tdStyle} className={item.groupOnly ? 'group-only' : ''}>
             {slotItem}
           </td>
         </tr>

--- a/src/ResourceView.js
+++ b/src/ResourceView.js
@@ -63,46 +63,19 @@ class ResourceView extends Component {
       }
       indents.push(indent)
 
-      let resourceRightSide = null
-      if (item.resourceRightSide) {
-        resourceRightSide = (
-          <div className={"resource-right-side"}>{item.resourceRightSide}</div>
-        )
-      }
-      console.log(resourceRightSide, item.resourceRightSide)
-
-      let slotItem
-      if (slotClickedFunc != undefined) {
-        slotItem = (
-          <a
-            title={item.slotName}
-            className="overflow-text header2-text clickable"
-            style={{ textAlign: 'left' }}
-            onClick={() => slotClickedFunc(schedulerData, item)}
-          >
-            <span className="slot-cell">
-              {indents}
-              <span className="slot-text">{item.slotName}</span>
-              {resourceRightSide}
-            </span>
-          </a>
-        )
-      } else {
-        slotItem = (
-          <div
-            title={item.slotName}
-            className="overflow-text header2-text non-clickable"
-            style={{ textAlign: 'left' }}
-          >
-            <span className="slot-cell">
-              {indents}
-              <span className="slot-text">{item.slotName}</span>
-              {resourceRightSide}
-            </span>
-          </div>
-        )
-      }
-
+      let slotItem = (
+        <div
+          title={item.slotName}
+          className="overflow-text header2-text"
+          style={{ textAlign: 'left' }}
+        >
+          <span className="slot-cell">
+            {indents}
+            <span className="slot-text">{item.slotName}</span>
+            {item.rightSide && <div className={'resource-right'}>{item.rightSide}</div>}
+          </span>
+        </div>
+      )
       if (!!slotItemTemplateResolver) {
         let temp = slotItemTemplateResolver(
           schedulerData,
@@ -126,7 +99,14 @@ class ResourceView extends Component {
 
       return (
         <tr key={item.slotId}>
-          <td data-resource-id={item.slotId} style={tdStyle} className={item.groupOnly ? 'group-only' : ''}>
+          <td
+            data-resource-id={item.slotId}
+            style={tdStyle}
+            className={item.groupOnly ? 'resource-group-only' : 'resource-row'}
+            onClick={() => {
+              slotClickedFunc(schedulerData, item)
+            }}
+          >
             {slotItem}
           </td>
         </tr>

--- a/src/ResourceView.js
+++ b/src/ResourceView.js
@@ -11,7 +11,6 @@ class ResourceView extends Component {
     schedulerData: PropTypes.object.isRequired,
     contentScrollbarHeight: PropTypes.number.isRequired,
     slotClickedFunc: PropTypes.func,
-    resourceCtaClickedFunc: PropTypes.func,
     slotItemTemplateResolver: PropTypes.func,
     toggleExpandFunc: PropTypes.func,
   }
@@ -21,7 +20,6 @@ class ResourceView extends Component {
       schedulerData,
       contentScrollbarHeight,
       slotClickedFunc,
-      resourceCtaClickedFunc,
       slotItemTemplateResolver,
       toggleExpandFunc,
     } = this.props
@@ -65,42 +63,46 @@ class ResourceView extends Component {
       }
       indents.push(indent)
 
-      let resourceCta = null
-      if (item.resourceCta) {
-        resourceCta = (
-          <div onClick={() => resourceCtaClickedFunc(item.slotId)} className={"resource-cta"}>{item.resourceCta}</div>
+      let resourceRightSide = null
+      if (item.resourceRightSide) {
+        resourceRightSide = (
+          <div className={"resource-right-side"}>{item.resourceRightSide}</div>
+        )
+      }
+      console.log(resourceRightSide, item.resourceRightSide)
+
+      let slotItem
+      if (slotClickedFunc != undefined) {
+        slotItem = (
+          <a
+            title={item.slotName}
+            className="overflow-text header2-text clickable"
+            style={{ textAlign: 'left' }}
+            onClick={() => slotClickedFunc(schedulerData, item)}
+          >
+            <span className="slot-cell">
+              {indents}
+              <span className="slot-text">{item.slotName}</span>
+              {resourceRightSide}
+            </span>
+          </a>
+        )
+      } else {
+        slotItem = (
+          <div
+            title={item.slotName}
+            className="overflow-text header2-text non-clickable"
+            style={{ textAlign: 'left' }}
+          >
+            <span className="slot-cell">
+              {indents}
+              <span className="slot-text">{item.slotName}</span>
+              {resourceRightSide}
+            </span>
+          </div>
         )
       }
 
-      let a =
-        slotClickedFunc != undefined ? (
-          <span className="slot-cell">
-            {indents}
-            <a
-              className="slot-text"
-              onClick={() => {
-                slotClickedFunc(schedulerData, item)
-              }}
-            >
-              {item.slotName}
-            </a>
-          </span>
-        ) : (
-          <span className="slot-cell">
-            {indents}
-            <span className="slot-text">{item.slotName}</span>
-            {resourceCta}
-          </span>
-        )
-      let slotItem = (
-        <div
-          title={item.slotName}
-          className="overflow-text header2-text"
-          style={{ textAlign: 'left' }}
-        >
-          {a}
-        </div>
-      )
       if (!!slotItemTemplateResolver) {
         let temp = slotItemTemplateResolver(
           schedulerData,

--- a/src/SchedulerData.js
+++ b/src/SchedulerData.js
@@ -849,6 +849,7 @@ export default class SchedulerData {
         hasChildren: false,
         expanded: true,
         render: true,
+        rightSide: slot.rightSide,
       }
       let id = slot.id
       let value = undefined

--- a/src/SchedulerData.js
+++ b/src/SchedulerData.js
@@ -849,7 +849,6 @@ export default class SchedulerData {
         hasChildren: false,
         expanded: true,
         render: true,
-        resourceCta: slot.resourceCta,
       }
       let id = slot.id
       let value = undefined

--- a/src/index.js
+++ b/src/index.js
@@ -115,6 +115,7 @@ class Scheduler extends Component {
     newEvent: PropTypes.func,
     subtitleGetter: PropTypes.func,
     eventItemClick: PropTypes.func,
+    eventBoundingBoxClick: PropTypes.func,
     viewEventClick: PropTypes.func,
     viewEventText: PropTypes.string,
     viewEvent2Click: PropTypes.func,

--- a/src/index.js
+++ b/src/index.js
@@ -123,7 +123,7 @@ class Scheduler extends Component {
     eventItemTemplateResolver: PropTypes.func,
     dndSources: PropTypes.array,
     slotClickedFunc: PropTypes.func,
-    resourceCtaClickedFunc: PropTypes.func,
+    resourceClickedFunc: PropTypes.func,
     toggleExpandFunc: PropTypes.func,
     slotItemTemplateResolver: PropTypes.func,
     nonAgendaCellHeaderTemplateResolver: PropTypes.func,

--- a/src/index.js
+++ b/src/index.js
@@ -123,7 +123,6 @@ class Scheduler extends Component {
     eventItemTemplateResolver: PropTypes.func,
     dndSources: PropTypes.array,
     slotClickedFunc: PropTypes.func,
-    resourceClickedFunc: PropTypes.func,
     toggleExpandFunc: PropTypes.func,
     slotItemTemplateResolver: PropTypes.func,
     nonAgendaCellHeaderTemplateResolver: PropTypes.func,


### PR DESCRIPTION
- Adds classes for styling - "group-only", event type, 
- Allows event bounding box to be clickable - used for click target of price per day
- Readjusts cells to line up with grid lines (only full pixels work here)
- Removes `resourceCtaClickedFunc` clicked function and uses native slot slotClickedFunc
- Allows items to start mid day (shift over a half cell width). This was necessary for the hover target to correctly span the entire event.  
- Dump resourceCta in favor of rightSide to allow deleted sites to use the same styling (click target is now on slot itself)